### PR TITLE
Allow unsetting and adding extra ENVs

### DIFF
--- a/charts/nginx-s3-gateway/templates/deployment.yaml
+++ b/charts/nginx-s3-gateway/templates/deployment.yaml
@@ -30,32 +30,61 @@ spec:
       containers:
         - name: {{ .Chart.Name }}
           env:
+          {{- with .Values.nginx.s3.bucketName }}
           - name: S3_BUCKET_NAME
-            value: "{{ .Values.nginx.s3.bucketName }}"
+            value: "{{ . }}"
+          {{ end }}
+          {{- with .Values.nginx.s3.accessKey }}
           - name: AWS_ACCESS_KEY_ID
-            value: "{{ .Values.nginx.s3.accessKey }}"
+            value: "{{ . }}"
+          {{ end }}
+          {{- with .Values.nginx.s3.secretKey }}
           - name: AWS_SECRET_ACCESS_KEY
-            value: "{{ .Values.nginx.s3.secretKey }}"
+            value: "{{ . }}"
+          {{ end }}
+          {{- with .Values.nginx.s3.server.host }}
           - name: S3_SERVER
-            value: "{{ .Values.nginx.s3.server.host }}"
+            value: "{{ . }}"
+          {{ end }}
+          {{- with .Values.nginx.s3.server.port }}
           - name: S3_SERVER_PORT
-            value: "{{ .Values.nginx.s3.server.port }}"
+            value: "{{ . }}"
+          {{ end }}
+          {{- with .Values.nginx.s3.server.proto }}
           - name: S3_SERVER_PROTO
-            value: "{{ .Values.nginx.s3.server.proto }}"
+            value: "{{ . }}"
+          {{ end }}
+          {{- with .Values.nginx.s3.awsregion }}
           - name: AWS_REGION
-            value: "{{ .Values.nginx.s3.awsregion }}"
+            value: "{{ . }}"
+          {{ end }}
+          {{- with .Values.nginx.s3.region }}
           - name: S3_REGION
-            value: "{{ .Values.nginx.s3.region }}"
+            value: "{{ . }}"
+          {{ end }}
+          {{- with .Values.nginx.s3.style }}
           - name: S3_STYLE
-            value: "{{ .Values.nginx.s3.style }}"
+            value: "{{ . }}"
+          {{ end }}
+          {{- with .Values.nginx.s3.debug }}
           - name: DEBUG
-            value: "{{ .Values.nginx.s3.debug }}"
+            value: "{{ . }}"
+          {{ end }}
+          {{- with .Values.nginx.s3.allowDirectoryListing }}
           - name: ALLOW_DIRECTORY_LIST
-            value: "{{ .Values.nginx.s3.allowDirectoryListing }}"
+            value: "{{ . }}"
+          {{ end }}
+          {{- with .Values.nginx.s3.provideIndexPage }}
           - name: PROVIDE_INDEX_PAGE
-            value: "{{ .Values.nginx.s3.provideIndexPage }}"
+            value: "{{ . }}"
+          {{ end }}
+          {{- with .Values.nginx.s3.awsSigsVersion }}
           - name: AWS_SIGS_VERSION
-            value:  "{{ .Values.nginx.s3.awsSigsVersion }}"
+            value: "{{ . }}"
+          {{ end }}
+          {{- with .Values.nginx.extraEnvs }}
+            {{ . | toYaml | nindent 10 }}
+          {{- end }}
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"

--- a/charts/nginx-s3-gateway/values.yaml
+++ b/charts/nginx-s3-gateway/values.yaml
@@ -82,6 +82,10 @@ tolerations: []
 affinity: {}
 
 nginx:
+  extraEnvs: []
+  ### Required for IRSA: https://github.com/nginxinc/nginx-s3-gateway/blob/main/docs/getting_started.md#running-on-eks-with-iam-roles-for-service-accounts
+  # - name: JS_TRUSTED_CERT_PATH
+  #   value: "/etc/ssl/certs/Amazon_Root_CA_1.pem"
   s3:
     bucketName: name
     accessKey: access


### PR DESCRIPTION
Changes necessary to run with IRSA authentication.

According to [docs](https://github.com/nginxinc/nginx-s3-gateway/blob/main/docs/getting_started.md#running-on-eks-with-iam-roles-for-service-accounts) one essentially needs to:
1. unset `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY`
2. set `JS_TRUSTED_CERT_PATH` to correct value

Current Deployment template doesn't allow that so I've added ability to unset any env by setting it to `''` while also adding `extraEnvs` to slot in custom ones.